### PR TITLE
FROM :bioc2020.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bioconductor/bioconductor_docker:devel
+FROM bioconductor/bioconductor_docker:bioc2020.1
 
 WORKDIR /home/rstudio
 


### PR DESCRIPTION
Will fix this error which participants may notice (no fault of your own)

Error in dyn.load(file, DLLpath = DLLpath, ...) : 
  unable to load shared object '/usr/local/lib/R/site-library/git2r/libs/git2r.so':
  libssh2.so.1: cannot open shared object file: No such file or directory